### PR TITLE
Refactor desktop pet code

### DIFF
--- a/desktop_pet/__init__.py
+++ b/desktop_pet/__init__.py
@@ -1,0 +1,1 @@
+from .pet import DesktopPet

--- a/desktop_pet/utils.py
+++ b/desktop_pet/utils.py
@@ -1,0 +1,25 @@
+import os
+import sys
+from PIL import Image, ImageTk
+
+
+def resource_path(relative_path: str) -> str:
+    """Resolve resource path for PyInstaller or normal execution."""
+    try:
+        base_path = sys._MEIPASS
+    except Exception:
+        base_path = os.path.abspath(".")
+    return os.path.join(base_path, relative_path)
+
+
+def load_gif_frames(path: str):
+    """Load all frames from a GIF and return as a list of PhotoImage."""
+    img = Image.open(path)
+    frames = []
+    try:
+        while True:
+            img.seek(len(frames))
+            frames.append(ImageTk.PhotoImage(img.copy()))
+    except EOFError:
+        pass
+    return frames

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 import tkinter as tk
-from pet import DesktopPet
+from desktop_pet.pet import DesktopPet
 
 if __name__ == "__main__":
     root = tk.Tk()


### PR DESCRIPTION
## Summary
- refactor pet into a package
- extract resource_path and GIF loader into `utils`
- add `PetState` enum and use it instead of booleans

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_68510e865084833091da971ce96e55eb