### PR TITLE
Improve idle behavior near cursor

### DIFF
--- a/desktop_pet/pet.py
+++ b/desktop_pet/pet.py
@@ -92,7 +92,15 @@ class DesktopPet:
 
     def auto_move(self):
         if self.state not in (PetState.DRAG, PetState.DASH):
-            if random.random() < 0.1:
+            pointer_x = self.master.winfo_pointerx()
+            pointer_y = self.master.winfo_pointery()
+            dx = pointer_x - (self.pos_x + 50)
+            dy = pointer_y - (self.pos_y + 50)
+            distance = (dx ** 2 + dy ** 2) ** 0.5
+
+            if distance < 50:
+                self.set_idle()
+            elif random.random() < 0.1:
                 self.start_dash()
             elif random.random() < 0.2:
                 self.set_idle()


### PR DESCRIPTION
## Summary
- when cursor is close to the pet, stop chasing it and idle instead

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68511c6d9c5883309c919a66620e9236